### PR TITLE
When config file cannot be open, print its path along with the error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,9 @@ fn main() -> Result<(), Error> {
             .join("worldclock.toml")
     };
 
-    let mut config: Config = toml::from_str(&std::fs::read_to_string(config_path)?)?;
+    let config_text = std::fs::read_to_string(&config_path)
+        .map_err(|e| eyre!("Could not open file: {}: {:#}", config_path.display(), e))?;
+    let mut config: Config = toml::from_str(&config_text)?;
 
     // If no clocks are specified, we will add a local one.
     if config.clocks.is_empty() {


### PR DESCRIPTION
Thank you for sharing this nifty command. I found it recently and it is very useful.

After I've installed it and ran it the first time, I got an error (no such file or directory). I figured out quickly that I was missing a config file.

While definitely not a big deal, I think it would be nice if it printed out what file it is looking for -- hence this small PR. I hope I am not out of place to issue this PR without asking first.

I am new to Rust -- I hope my diff is not too bad.